### PR TITLE
[FIX] Adding an empty object as validationMessages

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ function validateCustom(collection, validationError) {
 
     //grab custom model defined
     //validation messages
-    var messages = collection.validationMessages;
+    var messages = collection.validationMessages || {};
 
     //grab field names
     //from the messages


### PR DESCRIPTION
`Object.keys(messages)` was throwing an error if `Model.validationMessages` was not defined
